### PR TITLE
Add import rule to ruff and create new "reformat" session

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,14 +22,12 @@ repos:
         pass_filenames: false
         language_version: python3.9
 
-  - repo: local
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: 'v0.0.260'
     hooks:
       - id: ruff
-        name: ruff
-        entry: poetry run ruff check --force-exclude
-        language: system
-        types: [python]
-        require_serial: true
+        args: [--fix, --exit-non-zero-on-fix, --config=ruff.toml]
 
   - repo: local
     hooks:

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,9 +5,9 @@
 """Definition of nox sessions (tasks)."""
 
 import tempfile
+
 import nox  # pylint: disable=import-error
 from poetry.factory import Factory  # pylint: disable=import-error
-
 
 PACKAGE_NAME = "template_sandbox"
 
@@ -84,10 +84,11 @@ def lint(session: nox.Session) -> None:
 
 
 @nox.session(python=["3.9"])
-def black(session: nox.Session) -> None:
-    """Format with black."""
+def reformat(session: nox.Session) -> None:
+    """Fix with ruff and format with black."""
     args = session.posargs or locations
-    _install_on_nox_from_poetry_lock(session, ("--only", "lint"), "black")
+    _install_on_nox_from_poetry_lock(session, ("--only", "lint"), "black", "ruff")
+    session.run("ruff", "--fix", *args)
     session.run("black", *args)
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Enable all rules that are not library specific
-select = ["ANN", "ARG", "A", "B", "BLE", "C4", "COM", "D", "DTZ", "E", "ERA", "EXE", "EM", "F", "G", "FBT", "ICN", "INP", "INT", "ISC", "N", "PGH", "PIE", "PL", "PLE", "PLR", "PLW", "PT", "PTH", "PYI", "Q", "RET", "RSE", "RUF", "S", "SLF", "TCH", "TID", "TRY", "UP", "SIM", "W", "YTT"]
+select = ["ANN", "ARG", "A", "B", "BLE", "C4", "COM", "D", "DTZ", "E", "ERA", "EXE", "EM", "F", "G", "FBT", "I", "ICN", "INP", "INT", "ISC", "N", "PGH", "PIE", "PL", "PLE", "PLR", "PLW", "PT", "PTH", "PYI", "Q", "RET", "RSE", "RUF", "S", "SLF", "TCH", "TID", "TRY", "UP", "SIM", "W", "YTT"]
 ignore = ["D211", "D212"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/src/template_sandbox/__init__.py
+++ b/src/template_sandbox/__init__.py
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Template for python projects."""
-from importlib.metadata import version, PackageNotFoundError
-
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version(__name__)

--- a/tests/test_greeter.py
+++ b/tests/test_greeter.py
@@ -5,7 +5,7 @@
 """Placeholder test for the main placeholder."""
 
 import pytest
-from template_sandbox import greeter, __version__
+from template_sandbox import __version__, greeter
 
 
 def test_main_greeter_correct_greeting(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
- Fix #21 by selecting the "I" rule set.
- Rename black session to reformat and add ruff fix