### PR TITLE
Remove interrogate from the plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ In the (near?) future I will convert this template-sandbox into a proper cruft/c
 - [x] napoleon
 - [x] sphinx-autodoc-typehints
 - [x] towncrier
-- [ ] interrogate
 
 ### CI/CD
 


### PR DESCRIPTION
Reasons:
    - Unnecessary given the other packages
    - Causing problems with safety's check