### PR TITLE
52 fix renovate scheduling

### DIFF
--- a/docker-compose-renovate.yml
+++ b/docker-compose-renovate.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2023 The Template-Sandbox Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version: "3.8"
+services:
+  renovate:
+    image: renovate/renovate:35.66-slim
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - .:/app/
+    environment:
+      - RENOVATE_TOKEN=${RENOVATE_TOKEN}
+      - RENOVATE_PLATFORM=github
+      - RENOVATE_BASE_BRANCH=main
+      - RENOVATE_REPOSITORIES=rfguimaraes/template-sandbox
+      - RENOVATE_AUTODISCOVER=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,18 +30,5 @@ services:
       - WOODPECKER_SERVER=woodpecker-server:9000
       - WOODPECKER_AGENT_SECRET=${WOODPECKER_AGENT_SECRET}
 
-  renovate:
-    image: renovate/renovate:35.66-slim
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - .:/app/
-    environment:
-      - RENOVATE_TOKEN=${RENOVATE_TOKEN}
-      - RENOVATE_PLATFORM=github
-      - RENOVATE_BASE_BRANCH=main
-      - RENOVATE_REPOSITORIES=rfguimaraes/template-sandbox
-      - RENOVATE_AUTODISCOVER=false
-      - RENOVATE_SCHEDULE="0 * * * *"
-
 volumes:
   woodpecker-server-data:

--- a/run-renovate.sh
+++ b/run-renovate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2023 The Template-Sandbox Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+docker-compose -f docker-compose-renovate.yml up -d

--- a/run-renovate.sh
+++ b/run-renovate.sh
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-docker-compose -f docker-compose-renovate.yml up -d
+docker compose -f docker-compose-renovate.yml up -d --remove-orphans


### PR DESCRIPTION
The solution is just to separate renovate in its own file for docker compose and add a helper script that can be scheduled (for example, using cron).